### PR TITLE
Remove EOL category and use hidden instsaead

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -49,7 +49,8 @@ projects:
      doc_url: https://gazebosim.org/api/sim/9/
    - name: Gazebo Classic
      github_id: gazebosim/gazebo-classic
-     category: eol
+     category: robotics
+     show: False # EOL since January 2025
      license: Apache-2
      homepage: "https://classic.gazebosim.org/"
    - name: Webots
@@ -108,7 +109,8 @@ projects:
      doc_url: "https://mvsimulator.readthedocs.io/"
    - name: airsim
      github_id: microsoft/AirSim
-     category: eol
+     category: aerial
+     show: False # No longer maintained since 2022
      doc_url: "https://microsoft.github.io/AirSim/"
      license: mit
    - name: RotorS
@@ -349,7 +351,8 @@ projects:
      homepage: https://field-robotics-lab.github.io/dave.doc/
    - name: SVL Simulator
      github_id: lgsvl/simulator
-     category: eol
+     category: domain
+     show: False # Active developement suspended since 2022 January 1th
    - name: Flatland
      github_id: avidbots/flatland
      category: flatsim
@@ -360,17 +363,20 @@ projects:
      homepage: http://robwork.dk/
      license: apache-2
    - name: Simbad
-     category: eol
+     category: robotics
+     show: False # Hasn't been modified since 2011
      homepage: https://simbad.sourceforge.net/
      license: GNU-gpl2
    - name: Morse
      github_id: morse-simulator/morse
-     category: eol
+     category: robotics
+     show: False # No longer maintained as of 2020
      homepage: http://morse-simulator.github.io/
      license: OFL-1.1
    - name: Roboschool
      github_id: openai/roboschool
-     category: eol
+     category: robotics
+     show: False # Deprecated in 2019 in favor of Pybullet
      homepage: https://blog.openai.com/roboschool/
      license: mit
    - name: Ros2 For Unity
@@ -394,16 +400,18 @@ projects:
      homepage: https://deepdrive.io/
    - name: UUV Simulator
      github_id: uuvsimulator/uuv_simulator
-     category: eol
+     category: domain
+     show: False # Archived since 2023
      homepage: https://uuvsimulator.github.io/
      license: apache-2
    - name: Self Driving Car
      github_id: udacity/self-driving-car-sim
-     category: eol
+     category: domain
+     show: False # Archived since 2022
      license: mit
-   - name: ROS Intergration for unreal
+   - name: ROS1 Intergration for Unreal 4
      github_id: code-iai/ROSIntegration
-     category: eol
+     category: robotics
    - name: Safe Control Gym
      github_id: utiasDSL/safe-control-gym
      homepage: https://www.dynsyslab.org/safe-robot-learning/

--- a/projects.yaml
+++ b/projects.yaml
@@ -36,10 +36,6 @@ categories:
    - category: render
      title: Rendering engines
      subtitle: Rendering engines for robotic simulators
-   - category: eol
-     title: End of Life, Unmaintained or Deprecated
-     subtitle: Simulators that are announced End-Of-Life (EOL), are no longer maintained (no source code commits for longer than 5 years) or deprecated because underlying backends are no longer maintained or EOL.
-     
 
 projects:
    - name: Gazebo
@@ -50,7 +46,7 @@ projects:
    - name: Gazebo Classic
      github_id: gazebosim/gazebo-classic
      category: robotics
-     show: False # EOL since January 2025
+     show: False # End of Life since January 2025
      license: Apache-2
      homepage: "https://classic.gazebosim.org/"
    - name: Webots


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [ ] Add a project
- [ ] Update a project
- [ ] Remove a project
- [X] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
<!--- Use this section to describe your changes. We recommend only to add, update, or remove one project per pull request. If your PR adds a new project, just put the project name and a short description of the project here.-->
Remove the EOL category and add the projects as 'hidden' instead. This is because it might be nice to also see the source code of older simulators, but it will be difficult to see if it is no longer connected to the category

This removes the EOL category, changes all category: eol to

```
category: [name]
show: hiddenn # explanation why hidden
```

fixes #102 

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
