### PR TITLE
Add holoocean details

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -346,7 +346,7 @@ projects:
      fork_count: 21
      open_issue_count: 27
      closed_issue_count: 120
-     
+     license: MIT and Unreal Engine EULA
    - name: Holodeck
      github_id: BYU-PCCL/holodeck
      category: ml

--- a/projects.yaml
+++ b/projects.yaml
@@ -339,6 +339,14 @@ projects:
      category: maritime
      homepage: https://byu-holoocean.github.io/holoocean-docs/
      license: EULA and MIT
+     star_count: 50 #as of 5/13/2025
+     docs_url: https://byu-holoocean.github.io/holoocean-docs/
+     update_at: 5/13/2025
+     contributor_count: 8
+     fork_count: 21
+     open_issue_count: 27
+     closed_issue_count: 120
+     
    - name: Holodeck
      github_id: BYU-PCCL/holodeck
      category: ml


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [ ] Add a project
- [ x] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
Manually adds details for HoloOcean. I believe they aren't auto grabbed by the best-of-generator because holoocean is forked from Unreal Engine to follow Unreal Engines EULA, and so to be able to access the repo and it's statistics, i believe whatever user the best-of-generator uses would need to be added to the Unreal Engine dev group as described [here](https://www.unrealengine.com/en-US/ue-on-github) so here are some of the current statistics from our Repo.

**Checklist:**

- [] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
