### PR TITLE
Added the MRS FlightForge simulator of UAVs usage with ROS1, ROS2, or without ROS

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -790,9 +790,6 @@ projects:
      homepage: https://www.roblox.com/
      category: game
      license: proprietary
-   - name: FlightForge
-     github_id: ctu-mrs/flight_forge
-     category: aerial
    - name:  Ardupilot_Multiagent_Simulation
      github_id: aau-cns/Ardupilot_Multiagent_Simulation
      category: aerial


### PR DESCRIPTION
This pull request  changes the entery for the simulator FlightForge with correted license and pointing to the correct main repository